### PR TITLE
Cleanup python

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See test.json for reference
 
 ## Train
 Run
-```python ./train.py --dataset [DATASETNAME] --model [BACKBONENAME] --method [METHODNAME] [--OPTIONARG]```
+```python3 ./train.py --dataset [DATASETNAME] --model [BACKBONENAME] --method [METHODNAME] [--OPTIONARG]```
 
 For example, run `python ./train.py --dataset miniImagenet --model Conv4 --method baseline --train_aug`  
 Commands below follow this example, and please refer to io_utils.py for additional options.
@@ -62,11 +62,11 @@ Commands below follow this example, and please refer to io_utils.py for addition
 ## Save features
 Save the extracted feature before the classifaction layer to increase test speed. This is not applicable to MAML, but are required for other methods.
 Run
-```python ./save_features.py --dataset miniImagenet --model Conv4 --method baseline --train_aug```
+```python3 ./save_features.py --dataset miniImagenet --model Conv4 --method baseline --train_aug```
 
 ## Test
 Run
-```python ./test.py --dataset miniImagenet --model Conv4 --method baseline --train_aug```
+```python3 ./test.py --dataset miniImagenet --model Conv4 --method baseline --train_aug```
 
 ## Results
 * The test results will be recorded in `./record/results.txt`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ year={2019}
 
 ## Enviroment
  - Python3
- - [Pytorch](http://pytorch.org/) before 0.4 (for newer vesion, please see issue #3 )
+ - [Pytorch](http://pytorch.org/) >= 1.0
  - json
+
+To install the dependencies use `pip3 install -r requirements-cpu.txt -f https://download.pytorch.org/whl/torch_stable.html` or `pip3 install -r requirements-gpu.txt`.
 
 ## Getting started
 ### CUB

--- a/filelists/CUB/download_CUB.sh
+++ b/filelists/CUB/download_CUB.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 wget http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz
 tar -zxvf CUB_200_2011.tgz
-python write_CUB_filelist.py
+python3 write_CUB_filelist.py

--- a/filelists/emnist/download_emnist.sh
+++ b/filelists/emnist/download_emnist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 wget https://github.com/NanqingD/DAOSL/raw/master/data/emnist.zip 
 unzip emnist.zip
-python invert_emnist.py
-python write_cross_char_valnovel_filelist.py
+python3 invert_emnist.py
+python3 write_cross_char_valnovel_filelist.py

--- a/filelists/miniImagenet/download_miniImagenet.sh
+++ b/filelists/miniImagenet/download_miniImagenet.sh
@@ -4,5 +4,5 @@ wget https://raw.githubusercontent.com/twitter/meta-learning-lstm/master/data/mi
 wget https://raw.githubusercontent.com/twitter/meta-learning-lstm/master/data/miniImagenet/test.csv
 wget http://image-net.org/image/ILSVRC2015/ILSVRC2015_CLS-LOC.tar.gz 
 tar -zxvf ILSVRC2015_CLS-LOC.tar.gz
-python write_miniImagenet_filelist.py
-python write_cross_filelist.py
+python3 write_miniImagenet_filelist.py
+python3 write_cross_filelist.py

--- a/filelists/omniglot/download_omniglot.sh
+++ b/filelists/omniglot/download_omniglot.sh
@@ -14,6 +14,6 @@ mv $DATADIR/images_evaluation/* $DATADIR/
 rmdir $DATADIR/images_background
 rmdir $DATADIR/images_evaluation
 
-python rot_omniglot.py
-python write_omniglot_filelist.py
-python write_cross_char_base_filelist.py
+python3 rot_omniglot.py
+python3 write_omniglot_filelist.py
+python3 write_cross_char_base_filelist.py

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,4 @@
+torch==1.4.0+cpu
+torchvision==0.5.0+cpu
+Pillow
+h5py

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,4 @@
+torch>=1.0.0
+torchvision
+Pillow
+h5py


### PR DESCRIPTION
Add requirement files to easily install the dependencies with pip and use python3 consistently.

The code wasn't compatible with `pytorch<1.0.0` because `torchvision` uses 'torch.jit.annotations' which needs at least `pytorch>=1.0.0`.